### PR TITLE
Fix for git diff component to reset warning state after a file item transition and enhancements to git operations component

### DIFF
--- a/src/Components/DashBoard/Repository/GitComponents/GitDiffViewComponent.js
+++ b/src/Components/DashBoard/Repository/GitComponents/GitDiffViewComponent.js
@@ -24,7 +24,7 @@ export default function GitDiffViewComponent() {
   const [activeFileName, setActiveFileName] = useState("");
   const [isApiCalled, setIsApiCalled] = useState(false);
   const [isLangSelected, setIsLangSelected] = useState(false);
-  const [wranStatus, setWarnStatus] = useState("");
+  const [warnStatus, setWarnStatus] = useState("");
   const [lang, setLang] = useState("");
 
   const langEnum = {
@@ -146,6 +146,7 @@ export default function GitDiffViewComponent() {
   function fileDiffStatComponent(repoId, fileName) {
     const apiEndPoint = globalAPIEndpoint;
     setIsLangSelected(false);
+    setWarnStatus("");
 
     const payload = JSON.stringify(
       JSON.stringify({ repoId: repoId, fileName: fileName })
@@ -329,15 +330,15 @@ export default function GitDiffViewComponent() {
               ""
             )}
 
-            {wranStatus ? (
+            {warnStatus ? (
               <div className="text-center mx-auto my-4 p-4 rounded bg-yellow-300 border-yellow-800 font-sans font-medium my-auto">
-                {wranStatus}
+                {warnStatus}
               </div>
             ) : null}
 
             {diffStatState &&
             diffStatState !== "Click on a file item to see the difference" &&
-            !wranStatus ? (
+            !warnStatus ? (
               <div className="p-2 break-all w-3/4 mx-auto">
                 {diffStatState ? statFormat() : ""}
                 {fileLineDiffState &&

--- a/src/Components/DashBoard/Repository/GitComponents/GitOperation/GitOperationComponent.js
+++ b/src/Components/DashBoard/Repository/GitComponents/GitOperation/GitOperationComponent.js
@@ -14,6 +14,7 @@ import StageComponent from "./StageComponent";
 export default function GitOperationComponent(props) {
   library.add(fab);
   const { repoId } = props;
+  const { stateChange } = props;
 
   const [gitTrackedFiles, setGitTrackedFiles] = useState([]);
   const [gitUntrackedFiles, setGitUntrackedFiles] = useState([]);
@@ -163,7 +164,7 @@ export default function GitOperationComponent(props) {
 
   function stageGitComponent(stageItem, event) {
     let localViewReload = viewReload + 1;
-    
+
     event.target.innerHTML = "Staging...";
     event.target.style.backgroundColor = "gray";
     event.target.disabled = true;
@@ -265,6 +266,7 @@ export default function GitOperationComponent(props) {
   function getStagedFilesComponent() {
     function removeStagedItem(item, event) {
       let localViewReload = viewReload + 1;
+      stateChange();
 
       event.target.innerHTML = "removing...";
       event.target.style.backgroundColor = "gray";
@@ -309,6 +311,8 @@ export default function GitOperationComponent(props) {
 
     function removeAllStagedItems(event) {
       let localViewReload = viewReload + 1;
+      setStagedItems();
+      stateChange();
 
       event.target.innerHTML = "Removing...";
       event.target.style.backgroundColor = "gray";

--- a/src/Components/DashBoard/Repository/GitComponents/GitTrackedComponent.js
+++ b/src/Components/DashBoard/Repository/GitComponents/GitTrackedComponent.js
@@ -23,8 +23,13 @@ export default function GitTrackedComponent(props) {
   const [topMenuItemState, setTopMenuItemState] = useState("File View");
   const topMenuItems = ["File View", "Git Difference", "Git Operations"];
   const [noChangeMarker, setNoChangeMarker] = useState(false);
+  const [requestStateChange, setRequestChange] = useState(false);
 
   const { dispatch } = useContext(ContextProvider);
+
+  const operationStateChangeHandler = () => {
+    setRequestChange(true);
+  };
 
   const memoizedGitDiffView = useMemo(() => {
     return <GitDiffViewComponent repoId={props.repoId}></GitDiffViewComponent>;
@@ -32,12 +37,16 @@ export default function GitTrackedComponent(props) {
 
   const memoizedGitOperationView = useMemo(() => {
     return (
-      <GitOperationComponent repoId={props.repoId}></GitOperationComponent>
+      <GitOperationComponent
+        repoId={props.repoId}
+        stateChange={operationStateChangeHandler}
+      ></GitOperationComponent>
     );
   }, [props]);
 
   useEffect(() => {
     let apiEndPoint = globalAPIEndpoint;
+    setRequestChange(false);
 
     const payload = JSON.stringify(
       JSON.stringify({
@@ -98,9 +107,10 @@ export default function GitTrackedComponent(props) {
         }
       })
       .catch((err) => {
+        console.log(err);
         setNoChangeMarker(true);
       });
-  }, [props, dispatch]);
+  }, [props, dispatch, topMenuItemState, requestStateChange]);
 
   function diffPane() {
     var deletedArtifacts = [];


### PR DESCRIPTION
- The warning banner in diff component was not hidden even after a file item change. This was fixed to reset the state for every file change
- The File view pane in git operations always shows outdated component without being reactive. An interactive state transition has been added between git operations view and File view to resolve this