### PR TITLE
Replaced material icons with fontawesome icons. Redesigned home button in folder navigator view

### DIFF
--- a/.github/workflows/gitconvex.collab.actions.yml
+++ b/.github/workflows/gitconvex.collab.actions.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x, 13.x, 12.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.10",
-    "@material-ui/core": "^4.10.2",
-    "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",

--- a/src/Components/DashBoard/DashboardPaneComponents/LeftPane.js
+++ b/src/Components/DashBoard/DashboardPaneComponents/LeftPane.js
@@ -1,38 +1,45 @@
-import {
-  FolderOutlined,
-  HelpOutline,
-  SettingsOutlined,
-} from "@material-ui/icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { far } from "@fortawesome/free-regular-svg-icons";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useContext } from "react";
 import { NavLink } from "react-router-dom";
 import { ADD_FORM_CLOSE } from "../../../actionStore";
 import { ContextProvider } from "../../../context";
 
+
+
 export default function LeftPane(props) {
+  library.add(far, fas);
   const { dispatch } = useContext(ContextProvider);
   const menuItemParams = [
     {
       link: "/dashboard/repository",
       icon: (
-        <FolderOutlined
-          style={{ color: "grey", fontSize: "36px" }}
-        ></FolderOutlined>
+        <FontAwesomeIcon
+          icon={["far", "folder"]}
+          className="text-3xl text-gray-600"
+        ></FontAwesomeIcon>
       ),
       label: "Repositories",
     },
     {
       link: "/dashboard/settings",
       icon: (
-        <SettingsOutlined
-          style={{ color: "grey", fontSize: "36px" }}
-        ></SettingsOutlined>
+        <FontAwesomeIcon
+          icon={["fas", "cog"]}
+          className="text-3xl text-gray-600"
+        ></FontAwesomeIcon>
       ),
       label: "Settings",
     },
     {
       link: "/dashboard/help",
       icon: (
-        <HelpOutline style={{ color: "grey", fontSize: "36px" }}></HelpOutline>
+        <FontAwesomeIcon
+          icon={["far", "question-circle"]}
+          className="text-3xl text-gray-600"
+        ></FontAwesomeIcon>
       ),
       label: "Help",
     },
@@ -63,9 +70,9 @@ export default function LeftPane(props) {
               className="flex border-b border-black-100 p-3 hover:bg-gray-100 mx-2"
               key={entry.label}
             >
-              <div className="flex align-middle items-center my-auto">
+              <div className="flex gap-10 align-middle items-center my-auto">
                 <div className="text-sm">{entry.icon}</div>
-                <div className="ml-2 xl:text-2xl lg:text-2xl md:text-xl text-gray-700">
+                <div className="xl:text-2xl lg:text-2xl md:text-xl text-gray-700">
                   {entry.label}
                 </div>
               </div>

--- a/src/Components/DashBoard/Repository/RepoComponents/RepoDetails/FileExplorerComponent.js
+++ b/src/Components/DashBoard/Repository/RepoComponents/RepoDetails/FileExplorerComponent.js
@@ -276,7 +276,7 @@ export default function FileExplorerComponent(props) {
       {directoryNavigator ? (
         <div className="mx-6 p-3 font-sans flex gap-4 items-center justify-start">
           <div
-            className="w-1/6 text-gray-700 bg-gray-200 border border-dashed cursor-pointer justify-center p-3 text-center rounded shadow-md flex gap-4 my-auto items-center mx-4 text-xl"
+            className="w-1/6 text-gray-700 border-b-2 border-dashed cursor-pointer justify-center p-3 text-center rounded flex gap-4 my-auto items-center mx-6 text-xl transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105"
             onClick={() => {
               fetchFolderContent("", 0, false, true);
             }}
@@ -285,6 +285,7 @@ export default function FileExplorerComponent(props) {
               <FontAwesomeIcon icon={["fas", "home"]}></FontAwesomeIcon>
             </div>
             <div>Home</div>
+            <div className="text-2xl font-sans text-blue-400">./</div>
           </div>
           <div
             className="flex gap-4 items-center w-3/4 break-words overflow-x-auto"


### PR DESCRIPTION
- The meterial ui icons used for the left pane menu items are replaced with fontawesome icons
- Changed the home button in repo details components with a clean hover transition